### PR TITLE
Rename project to `tmate-replica`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 # Makefile.am
 
 # Obvious program stuff.
-bin_PROGRAMS = tmate-slave
+bin_PROGRAMS = tmate-replica
 CLEANFILES = tmate.1.mdoc tmate.1.man
 
 # Distribution tarball options.
@@ -72,7 +72,7 @@ DEFS += -D_LINUX_SOURCE_COMPAT=1
 endif
 
 # List of sources.
-dist_tmate_slave_SOURCES = \
+dist_tmate_replica_SOURCES = \
 	alerts.c \
 	arguments.c \
 	attributes.c \
@@ -185,7 +185,7 @@ dist_tmate_slave_SOURCES = \
 	tmate-daemon-legacy.c \
 	tmate-msgpack.c \
 	tmate-proxy.c \
-	tmate-slave.c \
+	tmate-replica.c \
 	tmate-ssh-client-pty.c \
 	tmate-ssh-daemon.c \
 	tmate-ssh-exec.c \
@@ -203,63 +203,63 @@ dist_tmate_slave_SOURCES = \
 	window.c \
 	xmalloc.c \
 	xterm-keys.c
-nodist_tmate_slave_SOURCES = osdep-@PLATFORM@.c
+nodist_tmate_replica_SOURCES = osdep-@PLATFORM@.c
 
 # Pile in all the compat/ stuff that is needed.
 if NO_FORKPTY
-nodist_tmate_slave_SOURCES += compat/forkpty-@PLATFORM@.c
+nodist_tmate_replica_SOURCES += compat/forkpty-@PLATFORM@.c
 endif
 if NO_IMSG
-nodist_tmate_slave_SOURCES += compat/imsg.c compat/imsg-buffer.c
+nodist_tmate_replica_SOURCES += compat/imsg.c compat/imsg-buffer.c
 endif
 if NO_CLOSEFROM
-nodist_tmate_slave_SOURCES += compat/closefrom.c
+nodist_tmate_replica_SOURCES += compat/closefrom.c
 endif
 if NO_DAEMON
-nodist_tmate_slave_SOURCES += compat/daemon.c
+nodist_tmate_replica_SOURCES += compat/daemon.c
 endif
 if NO_SETENV
-nodist_tmate_slave_SOURCES += compat/setenv.c
+nodist_tmate_replica_SOURCES += compat/setenv.c
 endif
 if NO_STRLCAT
-nodist_tmate_slave_SOURCES += compat/strlcat.c
+nodist_tmate_replica_SOURCES += compat/strlcat.c
 endif
 if NO_STRLCPY
-nodist_tmate_slave_SOURCES += compat/strlcpy.c
+nodist_tmate_replica_SOURCES += compat/strlcpy.c
 endif
 if NO_ASPRINTF
-nodist_tmate_slave_SOURCES += compat/asprintf.c
+nodist_tmate_replica_SOURCES += compat/asprintf.c
 endif
 if NO_FGETLN
-nodist_tmate_slave_SOURCES += compat/fgetln.c
+nodist_tmate_replica_SOURCES += compat/fgetln.c
 endif
 if NO_FPARSELN
-nodist_tmate_slave_SOURCES += compat/fparseln.c
+nodist_tmate_replica_SOURCES += compat/fparseln.c
 endif
 if NO_GETOPT
-nodist_tmate_slave_SOURCES += compat/getopt.c
+nodist_tmate_replica_SOURCES += compat/getopt.c
 endif
 if NO_STRCASESTR
-nodist_tmate_slave_SOURCES += compat/strcasestr.c
+nodist_tmate_replica_SOURCES += compat/strcasestr.c
 endif
 if NO_STRSEP
-nodist_tmate_slave_SOURCES += compat/strsep.c
+nodist_tmate_replica_SOURCES += compat/strsep.c
 endif
 if NO_VIS
-nodist_tmate_slave_SOURCES += compat/vis.c compat/unvis.c
+nodist_tmate_replica_SOURCES += compat/vis.c compat/unvis.c
 endif
 if NO_STRTONUM
-nodist_tmate_slave_SOURCES += compat/strtonum.c
+nodist_tmate_replica_SOURCES += compat/strtonum.c
 endif
 if NO_B64_NTOP
-nodist_tmate_slave_SOURCES += compat/b64_ntop.c
+nodist_tmate_replica_SOURCES += compat/b64_ntop.c
 endif
 if NO_CFMAKERAW
-nodist_tmate_slave_SOURCES += compat/cfmakeraw.c
+nodist_tmate_replica_SOURCES += compat/cfmakeraw.c
 endif
 if NO_OPENAT
-nodist_tmate_slave_SOURCES += compat/openat.c
+nodist_tmate_replica_SOURCES += compat/openat.c
 endif
 if NO_REALLOCARRAY
-nodist_tmate_slave_SOURCES += compat/reallocarray.c
+nodist_tmate_replica_SOURCES += compat/reallocarray.c
 endif

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tmate server side
 ==================
 
-tmate-slave is the server side part of [tmate.io](http://tmate.io/).
+tmate-replica is the server side part of [tmate.io](http://tmate.io/).
 
 Usage
 -----
@@ -11,7 +11,7 @@ See on [tmate.io](http://tmate.io/).
 Contributions
 -------------
 
-* Chef cookbook by [JJ Asghar](https://github.com/jjasghar): [https://github.com/jjasghar/chef-tmate-slave](https://github.com/jjasghar/chef-tmate-slave)
+* Chef cookbook by [JJ Asghar](https://github.com/jjasghar): [https://github.com/jjasghar/chef-tmate-replica](https://github.com/jjasghar/chef-tmate-replica)
 * Custom host:port support by [Paolo Mainardi](https://github.com/paolomainardi)
 
 License

--- a/client.c
+++ b/client.c
@@ -64,7 +64,7 @@ void		client_dispatch(struct imsg *, void *);
 void		client_dispatch_attached(struct imsg *);
 void		client_dispatch_wait(struct imsg *, const char *);
 const char     *client_exit_message(void);
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 void client_report_latency(int latency_ms);
 #endif
 
@@ -230,7 +230,7 @@ client_main(struct event_base *base, int argc, char **argv, int flags,
 	struct termios		 tio, saved_tio;
 	size_t			 size;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	/* Ignore SIGCHLD now or daemon() in the server will leave a zombie. */
 	signal(SIGCHLD, SIG_IGN);
 #endif
@@ -267,7 +267,7 @@ client_main(struct event_base *base, int argc, char **argv, int flags,
 		cmd_list_free(cmdlist);
 	}
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	fd = tmate_session->tmux_socket_fd;
 
 	/* Create client process structure (starts logging). */
@@ -311,7 +311,7 @@ client_main(struct event_base *base, int argc, char **argv, int flags,
 		fatal("pledge failed");
 #endif
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	/* Free stuff that is not used in the client. */
 	options_free(global_options);
 	options_free(global_s_options);
@@ -406,7 +406,7 @@ client_send_identify(const char *ttynam, const char *cwd)
 
 	proc_send(client_peer, MSG_IDENTIFY_FLAGS, -1, &flags, sizeof flags);
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	proc_send(client_peer, MSG_IDENTIFY_TMATE_IP_ADDRESS, -1,
 		  tmate_session->ssh_client.ip_address,
 		  strlen(tmate_session->ssh_client.ip_address) + 1);
@@ -647,7 +647,7 @@ client_dispatch_wait(struct imsg *imsg, const char *shellcmd)
 		if (datalen == 0 || data[datalen - 1] != '\0')
 			fatalx("bad MSG_SHELL string");
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 		exit(1);
 #else
 		clear_signals(0);
@@ -732,7 +732,7 @@ client_dispatch_attached(struct imsg *imsg)
 	}
 }
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 void client_report_latency(int latency_ms)
 {
 	proc_send(client_peer, MSG_LATENCY, -1, &latency_ms, sizeof(latency_ms));

--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -47,7 +47,7 @@ const struct cmd_entry cmd_break_pane_entry = {
 enum cmd_retval
 cmd_break_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -69,7 +69,7 @@ cmd_join_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 enum cmd_retval
 join_pane(struct cmd *self, struct cmd_q *cmdq, int not_same_window)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-kill-pane.c
+++ b/cmd-kill-pane.c
@@ -44,7 +44,7 @@ const struct cmd_entry cmd_kill_pane_entry = {
 enum cmd_retval
 cmd_kill_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct winlink		*wl = cmdq->state.tflag.wl;

--- a/cmd-paste-buffer.c
+++ b/cmd-paste-buffer.c
@@ -49,7 +49,7 @@ const struct cmd_entry cmd_paste_buffer_entry = {
 enum cmd_retval
 cmd_paste_buffer_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-pipe-pane.c
+++ b/cmd-pipe-pane.c
@@ -52,7 +52,7 @@ const struct cmd_entry cmd_pipe_pane_entry = {
 enum cmd_retval
 cmd_pipe_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -191,7 +191,7 @@ cmdq_continue_one(struct cmd_q *cmdq)
 	char		*tmp;
 	int		 flags = !!(cmd->flags & CMD_CONTROL);
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	int client_id;
 	if (!tmate_should_exec_cmd_locally(cmd->entry)) {
 		client_id = cmdq->client ? cmdq->client->id : -1;

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -47,7 +47,7 @@ const struct cmd_entry cmd_resize_pane_entry = {
 enum cmd_retval
 cmd_resize_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-respawn-pane.c
+++ b/cmd-respawn-pane.c
@@ -46,7 +46,7 @@ const struct cmd_entry cmd_respawn_pane_entry = {
 enum cmd_retval
 cmd_respawn_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-respawn-window.c
+++ b/cmd-respawn-window.c
@@ -45,7 +45,7 @@ const struct cmd_entry cmd_respawn_window_entry = {
 enum cmd_retval
 cmd_respawn_window_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-rotate-window.c
+++ b/cmd-rotate-window.c
@@ -42,7 +42,7 @@ const struct cmd_entry cmd_rotate_window_entry = {
 enum cmd_retval
 cmd_rotate_window_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct winlink		*wl = cmdq->state.tflag.wl;

--- a/cmd-select-layout.c
+++ b/cmd-select-layout.c
@@ -70,7 +70,7 @@ const struct cmd_entry cmd_previous_layout_entry = {
 enum cmd_retval
 cmd_select_layout_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args	*args = self->args;

--- a/cmd-send-keys.c
+++ b/cmd-send-keys.c
@@ -58,7 +58,7 @@ const struct cmd_entry cmd_send_prefix_entry = {
 enum cmd_retval
 cmd_send_keys_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-set-option.c
+++ b/cmd-set-option.c
@@ -185,7 +185,7 @@ cmd_set_option_exec(struct cmd *self, struct cmd_q *cmdq)
 	}
 
 	/* Start or stop timers if necessary. */
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	if (strcmp(oe->name, "automatic-rename") == 0) {
 		RB_FOREACH(w, windows, &windows) {
 			if (options_get_number(w->options, "automatic-rename"))

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -51,7 +51,7 @@ const struct cmd_entry cmd_split_window_entry = {
 enum cmd_retval
 cmd_split_window_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct args		*args = self->args;

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -45,7 +45,7 @@ const struct cmd_entry cmd_swap_pane_entry = {
 enum cmd_retval
 cmd_swap_pane_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return (CMD_RETURN_ERROR);
 #else
 	struct winlink          *src_wl, *dst_wl;

--- a/cmd-switch-client.c
+++ b/cmd-switch-client.c
@@ -47,7 +47,7 @@ const struct cmd_entry cmd_switch_client_entry = {
 enum cmd_retval
 cmd_switch_client_exec(struct cmd *self, struct cmd_q *cmdq)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	cmdq_error(cmdq, "client switch is not supported");
 	return (CMD_RETURN_ERROR);
 #else

--- a/compat/forkpty-aix.c
+++ b/compat/forkpty-aix.c
@@ -28,7 +28,7 @@
 pid_t
 forkpty(int *master, unused char *name, struct termios *tio, struct winsize *ws)
 {
-	int	slave = -1, fd, pipe_fd[2];
+	int	replica = -1, fd, pipe_fd[2];
 	char   *path, dummy;
 	pid_t	pid;
 
@@ -44,7 +44,7 @@ forkpty(int *master, unused char *name, struct termios *tio, struct winsize *ws)
 	if (name != NULL)
 		strlcpy(name, path, TTY_NAME_MAX);
 
-	if ((slave = open(path, O_RDWR|O_NOCTTY)) == -1)
+	if ((replica = open(path, O_RDWR|O_NOCTTY)) == -1)
 		goto out;
 
 	switch (pid = fork()) {
@@ -83,21 +83,21 @@ forkpty(int *master, unused char *name, struct termios *tio, struct winsize *ws)
 			fatal("open failed");
 		close(fd);
 
-		if (tio != NULL && tcsetattr(slave, TCSAFLUSH, tio) == -1)
+		if (tio != NULL && tcsetattr(replica, TCSAFLUSH, tio) == -1)
 			fatal("tcsetattr failed");
-		if (ioctl(slave, TIOCSWINSZ, ws) == -1)
+		if (ioctl(replica, TIOCSWINSZ, ws) == -1)
 			fatal("ioctl failed");
 
-		dup2(slave, 0);
-		dup2(slave, 1);
-		dup2(slave, 2);
-		if (slave > 2)
-			close(slave);
+		dup2(replica, 0);
+		dup2(replica, 1);
+		dup2(replica, 2);
+		if (replica > 2)
+			close(replica);
 
 		return (0);
 	}
 
-	close(slave);
+	close(replica);
 
 	close(pipe_fd[0]);
 	close(pipe_fd[1]);
@@ -106,8 +106,8 @@ forkpty(int *master, unused char *name, struct termios *tio, struct winsize *ws)
 out:
 	if (*master != -1)
 		close(*master);
-	if (slave != -1)
-		close(slave);
+	if (replica != -1)
+		close(replica);
 
 	close(pipe_fd[0]);
 	close(pipe_fd[1]);

--- a/compat/forkpty-sunos.c
+++ b/compat/forkpty-sunos.c
@@ -28,7 +28,7 @@
 pid_t
 forkpty(int *master, char *name, struct termios *tio, struct winsize *ws)
 {
-	int	slave = -1;
+	int	replica = -1;
 	char   *path;
 	pid_t	pid;
 
@@ -43,7 +43,7 @@ forkpty(int *master, char *name, struct termios *tio, struct winsize *ws)
 		goto out;
 	if (name != NULL)
 		strlcpy(name, path, TTY_NAME_MAX);
-	if ((slave = open(path, O_RDWR|O_NOCTTY)) == -1)
+	if ((replica = open(path, O_RDWR|O_NOCTTY)) == -1)
 		goto out;
 
 	switch (pid = fork()) {
@@ -54,35 +54,35 @@ forkpty(int *master, char *name, struct termios *tio, struct winsize *ws)
 
 		setsid();
 #ifdef TIOCSCTTY
-		if (ioctl(slave, TIOCSCTTY, NULL) == -1)
+		if (ioctl(replica, TIOCSCTTY, NULL) == -1)
 			fatal("ioctl failed");
 #endif
 
-		if (ioctl(slave, I_PUSH, "ptem") == -1)
+		if (ioctl(replica, I_PUSH, "ptem") == -1)
 			fatal("ioctl failed");
-		if (ioctl(slave, I_PUSH, "ldterm") == -1)
+		if (ioctl(replica, I_PUSH, "ldterm") == -1)
 			fatal("ioctl failed");
 
-		if (tio != NULL && tcsetattr(slave, TCSAFLUSH, tio) == -1)
+		if (tio != NULL && tcsetattr(replica, TCSAFLUSH, tio) == -1)
 			fatal("tcsetattr failed");
-		if (ioctl(slave, TIOCSWINSZ, ws) == -1)
+		if (ioctl(replica, TIOCSWINSZ, ws) == -1)
 			fatal("ioctl failed");
 
-		dup2(slave, 0);
-		dup2(slave, 1);
-		dup2(slave, 2);
-		if (slave > 2)
-			close(slave);
+		dup2(replica, 0);
+		dup2(replica, 1);
+		dup2(replica, 2);
+		if (replica > 2)
+			close(replica);
 		return (0);
 	}
 
-	close(slave);
+	close(replica);
 	return (pid);
 
 out:
 	if (*master != -1)
 		close(*master);
-	if (slave != -1)
-		close(slave);
+	if (replica != -1)
+		close(replica);
 	return (-1);
 }

--- a/control-notify.c
+++ b/control-notify.c
@@ -80,7 +80,7 @@ control_notify_window_layout_changed(struct window *w)
 		if (winlink_find_by_window_id(&s->windows, w->id) == NULL)
 			continue;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 		/*
 		 * When the last pane in a window is closed it won't have a
 		 * layout root and we don't need to inform the client about the

--- a/format.c
+++ b/format.c
@@ -361,7 +361,7 @@ format_cb_window_layout(struct format_tree *ft, struct format_entry *fe)
 	if (w == NULL)
 		return;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	fe->value = xstrdup("no layout");
 #else
 	if (w->saved_layout_root != NULL)
@@ -380,14 +380,14 @@ format_cb_window_visible_layout(struct format_tree *ft, struct format_entry *fe)
 	if (w == NULL)
 		return;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	fe->value = xstrdup("no layout");
 #else
 	fe->value = layout_dump(w->layout_root);
 #endif
 }
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 /* Callback for pane_start_command. */
 void
 format_cb_start_command(struct format_tree *ft, struct format_entry *fe)
@@ -1187,7 +1187,7 @@ format_defaults_pane(struct format_tree *ft, struct window_pane *wp)
 	format_add(ft, "pane_active", "%d", wp == wp->window->active);
 	format_add(ft, "pane_input_off", "%d", !!(wp->flags & PANE_INPUTOFF));
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	status = wp->status;
 	if (wp->fd == -1 && WIFEXITED(status))
 		format_add(ft, "pane_dead_status", "%d", WEXITSTATUS(status));
@@ -1207,7 +1207,7 @@ format_defaults_pane(struct format_tree *ft, struct window_pane *wp)
 
 	format_add(ft, "pane_tty", "%s", wp->tty);
 	format_add(ft, "pane_pid", "%ld", (long) wp->pid);
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	format_add_cb(ft, "pane_start_command", format_cb_start_command);
 	format_add_cb(ft, "pane_current_command", format_cb_current_command);
 	format_add_cb(ft, "pane_current_path", format_cb_current_path);

--- a/input-keys.c
+++ b/input-keys.c
@@ -23,7 +23,7 @@
 
 #include "tmux.h"
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 
 /*
  * This file is rather misleadingly named, it contains the code which takes a

--- a/input.c
+++ b/input.c
@@ -839,7 +839,7 @@ input_parse(struct window_pane *wp)
 {
 	struct input_ctx		*ictx = wp->ictx;
 	const struct input_transition	*itr;
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	struct evbuffer			*evb = wp->event_input;
 #else
 	struct evbuffer			*evb = wp->event->input;
@@ -961,7 +961,7 @@ input_get(struct input_ctx *ictx, u_int validx, int minval, int defval)
 void
 input_reply(struct input_ctx *ictx, const char *fmt, ...)
 {
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	va_list	ap;
 	char   *reply;
 

--- a/job.c
+++ b/job.c
@@ -49,7 +49,7 @@ job_run(const char *cmd, struct session *s, const char *cwd,
 	int		 nullfd, out[2];
 	const char	*home;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return NULL;
 #endif
 

--- a/layout-custom.c
+++ b/layout-custom.c
@@ -23,7 +23,7 @@
 
 #include "tmux.h"
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 
 struct layout_cell     *layout_find_bottomright(struct layout_cell *);
 u_short			layout_checksum(const char *);

--- a/layout-set.c
+++ b/layout-set.c
@@ -22,7 +22,7 @@
 
 #include "tmux.h"
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 
 /*
  * Set window layouts - predefined methods to arrange windows. These are

--- a/layout.c
+++ b/layout.c
@@ -22,7 +22,7 @@
 
 #include "tmux.h"
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 
 /*
  * The window layout is a tree of cells each of which can be one of: a

--- a/monitor/monitor.rb
+++ b/monitor/monitor.rb
@@ -27,7 +27,7 @@ loop do
 
 
   Dir['/proc/*/cmdline'].map do |f|
-    if File.read(f) =~ /^tmate-slave \[(.+)\] \((.+)\) (.+)$/
+    if File.read(f) =~ /^tmate-replica \[(.+)\] \((.+)\) (.+)$/
       token = $1
       role = $2
       ip = $3

--- a/names.c
+++ b/names.c
@@ -25,7 +25,7 @@
 
 #include "tmux.h"
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 
 char *
 default_window_name(struct window *w)

--- a/proc.c
+++ b/proc.c
@@ -172,7 +172,7 @@ proc_start(const char *name, struct event_base *base, int forkflag,
 	struct tmuxproc	*tp;
 	struct utsname	 u;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	if (forkflag)
 		fatal("can't fork");
 #else
@@ -210,7 +210,7 @@ proc_start(const char *name, struct event_base *base, int forkflag,
 	tp = xcalloc(1, sizeof *tp);
 	tp->name = xstrdup(name);
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	tp->signalcb = signalcb;
 	set_signals(proc_signal_cb, tp);
 #endif
@@ -226,7 +226,7 @@ proc_loop(struct tmuxproc *tp, int (*loopcb)(void))
 		event_loop(EVLOOP_ONCE);
 	while (!tp->exit && (loopcb == NULL || !loopcb ()));
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	/* flush data on sockets */
 	event_loop(EVLOOP_ONCE | EVLOOP_NONBLOCK);
 #endif

--- a/resize.c
+++ b/resize.c
@@ -61,7 +61,7 @@ recalculate_sizes(void)
 		TAILQ_FOREACH(c, &clients, entry) {
 			if (c->flags & CLIENT_SUSPENDED)
 				continue;
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 			if (c->flags & CLIENT_READONLY)
 				continue;
 #endif
@@ -78,7 +78,7 @@ recalculate_sizes(void)
 			}
 		}
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 		if (tmate_has_proxy()) {
 			if (tmate_session->proxy_sy < ssy)
 				ssy = tmate_session->proxy_sy;
@@ -155,7 +155,7 @@ recalculate_sizes(void)
 		is_zoomed = w->flags & WINDOW_ZOOMED;
 		if (is_zoomed)
 			window_unzoom(w);
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 		layout_resize(w, ssx, ssy);
 #endif
 		window_resize(w, ssx, ssy);

--- a/server-client.c
+++ b/server-client.c
@@ -96,7 +96,7 @@ server_client_get_key_table(struct client *c)
 	return (name);
 }
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 u_int	next_client_id;
 #endif
 
@@ -110,7 +110,7 @@ server_client_create(int fd)
 
 	c = xcalloc(1, sizeof *c);
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	c->id = next_client_id++;
 	c->ip_address = NULL;
 	c->pubkey = NULL;
@@ -204,7 +204,7 @@ server_client_lost(struct client *c)
 	TAILQ_REMOVE(&clients, c, entry);
 	log_debug("lost client %p", c);
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	tmate_notify_client_left(tmate_session, c);
 #endif
 
@@ -252,7 +252,7 @@ server_client_lost(struct client *c)
 	cmdq_free(c->cmdq);
 	c->cmdq = NULL;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	free(c->ip_address);
 	c->ip_address = NULL;
 	free(c->pubkey);
@@ -630,7 +630,7 @@ server_client_handle_key(struct client *c, key_code key)
 		window_unzoom(w);
 		wp = window_pane_at_index(w, key - '0');
 		if (wp != NULL && window_pane_visible(wp))
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 			tmate_client_set_active_pane(c->id, key - '0', wp->id);
 #else
 			window_set_active_pane(w, wp);
@@ -781,7 +781,7 @@ server_client_loop(void)
 	RB_FOREACH(w, windows, &windows) {
 		w->flags &= ~WINDOW_REDRAW;
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 			if (wp->fd != -1) {
 				server_client_check_focus(wp);
 				server_client_check_resize(wp);
@@ -793,7 +793,7 @@ server_client_loop(void)
 	}
 }
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 /* Check if pane should be resized. */
 void
 server_client_check_resize(struct window_pane *wp)
@@ -1074,7 +1074,7 @@ server_client_dispatch(struct imsg *imsg, void *arg)
 	case MSG_IDENTIFY_ENVIRON:
 	case MSG_IDENTIFY_CLIENTPID:
 	case MSG_IDENTIFY_DONE:
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	case MSG_IDENTIFY_TMATE_IP_ADDRESS:
 	case MSG_IDENTIFY_TMATE_PUBKEY:
 	case MSG_IDENTIFY_TMATE_READONLY:
@@ -1149,7 +1149,7 @@ server_client_dispatch(struct imsg *imsg, void *arg)
 
 		server_client_dispatch_shell(c);
 		break;
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	case MSG_LATENCY:
 		{
 		int latency_ms;
@@ -1280,7 +1280,7 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 		memcpy(&c->pid, data, sizeof c->pid);
 		log_debug("client %p IDENTIFY_CLIENTPID %ld", c, (long)c->pid);
 		break;
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	case MSG_IDENTIFY_TMATE_IP_ADDRESS:
 		if (datalen == 0 || data[datalen - 1] != '\0')
 			fatalx("bad MSG_IDENTIFY_TMATE_IP_ADDRESS string");
@@ -1344,7 +1344,7 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 	if (!(c->flags & CLIENT_CONTROL))
 		c->flags |= CLIENT_TERMINAL;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	tmate_notify_client_join(tmate_session, c);
 #endif
 }

--- a/server-fn.c
+++ b/server-fn.c
@@ -294,7 +294,7 @@ void
 server_destroy_pane(struct window_pane *wp, int hooks)
 {
 	struct window		*w = wp->window;
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	int			 old_fd;
 	struct screen_write_ctx	 ctx;
 	struct grid_cell	 gc;
@@ -330,7 +330,7 @@ server_destroy_pane(struct window_pane *wp, int hooks)
 #endif
 
 	server_unzoom_window(w);
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	layout_close_pane(wp);
 	window_remove_pane(w, wp);
 

--- a/server.c
+++ b/server.c
@@ -135,7 +135,7 @@ server_create_socket(void)
 int
 server_start(struct event_base *base, int lockfd, char *lockfile)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	server_proc = proc_start("server", base, 0, server_signal);
 #else
 	int	pair[2];
@@ -170,7 +170,7 @@ server_start(struct event_base *base, int lockfd, char *lockfile)
 
 	gettimeofday(&start_time, NULL);
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	server_fd = tmate_session->tmux_socket_fd;
 #else
 	server_fd = server_create_socket();
@@ -188,20 +188,20 @@ server_start(struct event_base *base, int lockfd, char *lockfile)
 
 	start_cfg();
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	status_prompt_load_history();
 #endif
 
 	server_add_accept(0);
 
 	proc_loop(server_proc, server_loop);
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	status_prompt_save_history();
 #endif
 	exit(0);
 }
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 static int tmate_server_request_exit;
 #endif
 
@@ -213,7 +213,7 @@ server_loop(void)
 
 	server_client_loop();
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	if (!ssh_is_connected(tmate_session->ssh_client.session) &&
 	    !tmate_server_request_exit) {
 		/*
@@ -258,7 +258,7 @@ server_send_exit(void)
 	struct client	*c, *c1;
 	struct session	*s, *s1;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	tmate_server_request_exit = 1;
 #endif
 

--- a/session.c
+++ b/session.c
@@ -344,7 +344,7 @@ session_new(struct session *s, const char *name, int argc, char **argv,
 		shell = _PATH_BSHELL;
 
 	hlimit = options_get_number(s->options, "history-limit");
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	hlimit = hlimit > TMATE_HLIMIT ? TMATE_HLIMIT : hlimit;
 #endif
 	w = window_create(name, argc, argv, path, shell, cwd, env, s->tio,

--- a/signal.c
+++ b/signal.c
@@ -24,7 +24,7 @@
 
 #include "tmux.h"
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 
 struct event	ev_sighup;
 struct event	ev_sigchld;

--- a/status.c
+++ b/status.c
@@ -217,7 +217,7 @@ status_redraw_get_left(struct client *c, time_t t, struct grid_cell *gc,
 	char		*left;
 	size_t		 leftlen;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	left = xstrdup(tmate_left_status ?: "");
 #else
 	style_apply_update(gc, s->options, "status-left-style");
@@ -243,7 +243,7 @@ status_redraw_get_right(struct client *c, time_t t, struct grid_cell *gc,
 	char		*right;
 	size_t		 rightlen;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	right = xstrdup(tmate_right_status ?: "");
 #else
 	style_apply_update(gc, s->options, "status-right-style");
@@ -530,7 +530,7 @@ status_print(struct client *c, struct winlink *wl, time_t t,
 	const char	*fmt;
 	char   		*text;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	/* TODO use the host winlink status */
 #endif
 

--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -217,7 +217,7 @@ static void client_bootstrap(struct tmate_session *_session)
 	tmate_start_ssh_latency_probes(client, &ssh_server_cb, TMATE_SSH_KEEPALIVE * 1000);
 	register_on_ssh_read(client);
 
-	tmate_spawn_slave(_session);
+	tmate_spawn_replica(_session);
 	/* never reached */
 }
 

--- a/tmate.h
+++ b/tmate.h
@@ -185,7 +185,7 @@ struct tmate_ssh_client {
 extern void tmate_ssh_server_main(struct tmate_session *session,
 				  const char *keys_dir, const char *bind_addr, int port);
 
-/* tmate-slave.c */
+/* tmate-replica.c */
 
 #ifdef DEVENV
 #define TMATE_SSH_DEFAULT_PORT 2200
@@ -254,7 +254,7 @@ extern struct tmate_session *tmate_session;
 extern void tmate_get_random_bytes(void *buffer, ssize_t len);
 extern long tmate_get_random_long(void);
 extern void request_server_termination(void);
-extern void tmate_spawn_slave(struct tmate_session *session);
+extern void tmate_spawn_replica(struct tmate_session *session);
 extern void set_session_token(struct tmate_session *session, const char *token);
 
 /* tmate-proxy.c */

--- a/tmux.c
+++ b/tmux.c
@@ -44,7 +44,7 @@ struct hooks	*global_hooks;
 struct timeval	 start_time;
 const char	*socket_path;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 __dead void	 usage(void);
 static char	*make_label(const char *);
 
@@ -167,7 +167,7 @@ setblocking(int fd, int state)
 	}
 }
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 const char * find_home(void) { return NULL; }
 int areshell(__unused const char *shell) { return 0; }
 #else
@@ -350,7 +350,7 @@ main(int argc, char **argv)
 }
 #endif
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 void tmux_server_init(void)
 {
 	global_hooks = hooks_create(NULL);

--- a/tmux.h
+++ b/tmux.h
@@ -19,7 +19,7 @@
 #ifndef TMUX_H
 #define TMUX_H
 
-#define TMATE_SLAVE
+#define TMATE_REPLICA
 
 #define PROTOCOL_VERSION 8
 
@@ -414,7 +414,7 @@ enum msgtype {
 	MSG_IDENTIFY_CLIENTPID,
 	MSG_IDENTIFY_CWD,
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	/* Next time put this after TMATE_LATENCY */
 	MSG_IDENTIFY_TMATE_IP_ADDRESS,
 	MSG_IDENTIFY_TMATE_PUBKEY,
@@ -439,7 +439,7 @@ enum msgtype {
 	MSG_UNLOCK,
 	MSG_WAKEUP,
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	MSG_LATENCY = 300
 #endif
 };
@@ -873,7 +873,7 @@ struct window_pane {
 
 	struct window	*window;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	struct layout_cell *layout_cell;
 	struct layout_cell *saved_layout_cell;
 #endif
@@ -892,7 +892,7 @@ struct window_pane {
 #define PANE_FOCUSPUSH 0x10
 #define PANE_INPUTOFF 0x20
 #define PANE_CHANGED 0x40
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 #define PANE_KILL 0x80
 #endif
 
@@ -905,7 +905,7 @@ struct window_pane {
 	char		 tty[TTY_NAME_MAX];
 	int		 status;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	struct evbuffer *event_input;
 #else
 	int		 fd;
@@ -957,7 +957,7 @@ struct window {
 
 	int		 lastlayout;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	struct layout_cell *layout_root;
 	struct layout_cell *saved_layout_root;
 	char		*old_layout;
@@ -975,7 +975,7 @@ struct window {
 #define WINDOW_FORCEWIDTH 0x2000
 #define WINDOW_FORCEHEIGHT 0x4000
 #define WINDOW_ALERTFLAGS (WINDOW_BELL|WINDOW_ACTIVITY|WINDOW_SILENCE)
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 #define WINDOW_KILL 0x8000
 #endif
 
@@ -1001,7 +1001,7 @@ struct winlink {
 #define WINLINK_ACTIVITY 0x2
 #define WINLINK_SILENCE 0x4
 #define WINLINK_ALERTFLAGS (WINLINK_BELL|WINLINK_ACTIVITY|WINLINK_SILENCE)
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 #define WINLINK_KILL 0x80
 #endif
 
@@ -1251,7 +1251,7 @@ struct message_entry {
 
 /* Client connection. */
 struct client {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	int		 id;
 #endif
 	struct tmuxpeer	*peer;
@@ -1305,7 +1305,7 @@ struct client {
 #define CLIENT_256COLOURS 0x20000
 #define CLIENT_IDENTIFIED 0x40000
 #define CLIENT_STATUSFORCE 0x80000
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 #define CLIENT_TMATE_NOTIFIED_JOIN 0x10000000
 #endif
 	int		 flags;
@@ -1339,7 +1339,7 @@ struct client {
 	struct cmd_q	*cmdq;
 	int		 references;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	char		*ip_address;
 	char		*pubkey;
 	int		readonly;
@@ -2012,7 +2012,7 @@ void	 input_reset(struct window_pane *, int);
 struct evbuffer *input_pending(struct window_pane *);
 void	 input_parse(struct window_pane *);
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 /* input-key.c */
 void	 input_key(struct window_pane *, key_code, struct mouse_event *);
 #endif

--- a/tty-term.c
+++ b/tty-term.c
@@ -407,7 +407,7 @@ tty_term_find(char *name, int fd, char **cause)
 	LIST_INSERT_HEAD(&tty_terms, term, entry);
 
 	/* we are in a jail, no access to files */
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	/* Set up curses terminal. */
 	if (setupterm(name, fd, &error) != OK) {
 		switch (error) {
@@ -537,7 +537,7 @@ error:
 void
 tty_term_free(struct tty_term *term)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	/*
 	 * We need to keep the term in memory, because we are in a jail, with
 	 * no file system, so we can't reload them.

--- a/tty.c
+++ b/tty.c
@@ -166,7 +166,7 @@ tty_init(struct tty *tty, struct client *c, int fd, char *term)
 	tty->fd = fd;
 	tty->client = c;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	tty->path = NULL;
 #else
 	if ((path = ttyname(fd)) == NULL)

--- a/window-copy.c
+++ b/window-copy.c
@@ -61,7 +61,7 @@ window_copy_init(struct window_pane *wp)
 	data->searchtype = WINDOW_COPY_OFF;
 	data->searchstr = NULL;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	if (wp->fd != -1)
 		bufferevent_disable(wp->event, EV_READ|EV_WRITE);
 #endif
@@ -125,7 +125,7 @@ window_copy_free(struct window_pane *wp)
 {
 	struct window_copy_mode_data	*data = wp->modedata;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	if (wp->fd != -1)
 		bufferevent_enable(wp->event, EV_READ|EV_WRITE);
 #endif
@@ -1407,7 +1407,7 @@ window_copy_copy_pipe(struct window_pane *wp, struct session *sess,
 	struct format_tree	*ft;
 	char			*expanded;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	/* that job_run() is not going to end well */
 	return;
 #endif

--- a/window.c
+++ b/window.c
@@ -297,7 +297,7 @@ window_create1(u_int sx, u_int sy)
 	TAILQ_INIT(&w->panes);
 	w->active = NULL;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	w->lastlayout = -1;
 	w->layout_root = NULL;
 #endif
@@ -327,7 +327,7 @@ window_create(const char *name, int argc, char **argv, const char *path,
 
 	w = window_create1(sx, sy);
 	wp = window_add_pane(w, hlimit);
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	layout_init(w, wp);
 #endif
 
@@ -352,7 +352,7 @@ window_destroy(struct window *w)
 {
 	RB_REMOVE(windows, &windows, w);
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	if (w->layout_root != NULL)
 		layout_free_cell(w->layout_root);
 	if (w->saved_layout_root != NULL)
@@ -523,7 +523,7 @@ window_zoom(struct window_pane *wp)
 	if (w->active != wp)
 		window_set_active_pane(w, wp);
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	TAILQ_FOREACH(wp1, &w->panes, entry) {
 		wp1->saved_layout_cell = wp1->layout_cell;
 		wp1->layout_cell = NULL;
@@ -548,7 +548,7 @@ window_unzoom(struct window *w)
 
 	w->flags &= ~WINDOW_ZOOMED;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	layout_free(w);
 	w->layout_root = w->saved_layout_root;
 	w->saved_layout_root = NULL;
@@ -752,7 +752,7 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 	wp->shell = NULL;
 	wp->cwd = NULL;
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	wp->event_input = evbuffer_new();
 #else
 	wp->fd = -1;
@@ -761,7 +761,7 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 
 	wp->mode = NULL;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	wp->layout_cell = NULL;
 #endif
 
@@ -798,7 +798,7 @@ window_pane_destroy(struct window_pane *wp)
 	if (event_initialized(&wp->timer))
 		evtimer_del(&wp->timer);
 
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	evbuffer_free(wp->event_input);
 #else
 	if (wp->fd != -1) {
@@ -834,7 +834,7 @@ window_pane_spawn(struct window_pane *wp, int argc, char **argv,
     const char *path, const char *shell, const char *cwd, struct environ *env,
     struct termios *tio, char **cause)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	return 0;
 #else
 	struct winsize	 ws;
@@ -967,7 +967,7 @@ void
 window_pane_read_callback(__unused struct bufferevent *bufev, void *data)
 {
 	struct window_pane	*wp = data;
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	struct evbuffer		*evb = wp->event_input;
 #else
 	struct evbuffer		*evb = wp->event->input;
@@ -1154,7 +1154,7 @@ void
 window_pane_key(struct window_pane *wp, struct client *c, struct session *s,
     key_code key, struct mouse_event *m)
 {
-#ifdef TMATE_SLAVE
+#ifdef TMATE_REPLICA
 	/*
 	 * pane_id == -1,  which means that we should send the keys to
 	 * the active pane. This is better due to latency issues in
@@ -1199,7 +1199,7 @@ window_pane_visible(struct window_pane *wp)
 {
 	struct window	*w = wp->window;
 
-#ifndef TMATE_SLAVE
+#ifndef TMATE_REPLICA
 	if (wp->layout_cell == NULL)
 		return (0);
 #endif


### PR DESCRIPTION
Rename project to `tmate-server`

Hey, I just discovered this project,
and I'm super excited about being able to pair with my brother
who lives across the country.
Thanks for all your work!

I was scrolling down your homepage to try and figure out how it worked,
and I saw this github repository listed.
The name `tmate-slave` jumped out at me,
and though I love the project,
I was a bit turned off by the name.
Many software projects are moving away
from the `master/slave` naming convention,
in an attempt to present a more inclusive environment.

A couple years ago Drupal changed their terminology
away from `master/slave`,
and [this comment from the issue discussion][drupal-comment]
captured their reasoning beautifully.

[drupal-comment]: https://www.drupal.org/node/2275877#comment-8831441

Drupal's, and Django's, and other projects' renamings
were met with many grateful responses,
and it is becoming the norm to use `primary / replica`,
or in this case something like `client / sever`,
to describe the relationship.

I did my best to replace the instances of `slave` with `server`,
and it looks like everything still works correctly.
Let me know if it looks good to you.

Again, I really enjoy your project and I can't wait
to start using it regularly.
Thanks for your contributions,
and for helping make open source more accessible to all!