### PR TITLE
Fix docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y git build-essential automake cmake pkg-config libssl-dev 
 RUN mkdir /src && cd /src/ &&\
         # Latest libssh requires cmake >= 3.3.0 which is not available in jessie.
 	# jessie-backports provides 3.6.2 but this pulls too many dependencies in.
-	git clone -b libssh-0.7.6 git://git.libssh.org/projects/libssh.git &&\
+	git clone git://git.libssh.org/projects/libssh.git && cd libssh && git checkout 9dc650b7fbaef422e2a148322563106f3fbacb7a && cd - &&\
 	git clone https://github.com/msgpack/msgpack-c.git &&\
 	git clone https://github.com/tmate-io/tmate-slave.git
 


### PR DESCRIPTION
rewind libssh to earliest introduction of SSH_BIND_OPTIONS_IMPORT_KEY instead of cloning from a stale tag. 

libssh-0.7.x - doesn't have SSH_BIND_OPTIONS_IMPORT_KEY
libssh-0.8.x - has a cmake dependency

proof of build: https://cloud.docker.com/repository/registry-1.docker.io/cgetzen/tmate-slave/builds/3b352e83-f73d-4ea5-8eed-957cd1a43f5b
proof of previous failure: https://cloud.docker.com/repository/docker/cgetzen/tmate-slave/builds/d1e6c439-06c3-4a82-88e5-ac1f39bad60f

follow up issue https://github.com/tmate-io/tmate-slave/issues/55.