### PR TITLE
Correct create_key script

### DIFF
--- a/create_keys.sh
+++ b/create_keys.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eu
 
+SIG=''
 gen_key() {
   keytype=$1
   ks="${keytype}_"


### PR DESCRIPTION
Depending on the shell, the $SIG wasn't set, leading in errors and
crash.
By ensuring that var exists before anything is done to it (especially
before the sub creation), we avoid any issues regarding scoping.