### PR TITLE
ssh-server: Deny to auth using 'none' method

### DIFF
--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -207,10 +207,7 @@ static int auth_none_cb(ssh_session session, const char *user, void *userdata)
 
 	struct tmate_ssh_client *client = userdata;
 
-	client->username = xstrdup(user);
-	client->pubkey = xstrdup("none");
-
-	return SSH_AUTH_SUCCESS;
+	return SSH_AUTH_DENIED;
 }
 
 static struct ssh_server_callbacks_struct ssh_server_cb = {


### PR DESCRIPTION
This method is normally used to determine what capablities the server
supports. Also the libssh client uses the 'none' method to exchange
important messages between the client and server like SSH_MSG_EXT_INFO.