### PR TITLE
tmate-ssh-server: Explicitly parse config to avoid options override

### DIFF
--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -405,6 +405,12 @@ static ssh_bind prepare_ssh(const char *keys_dir, const char *bind_addr, int por
 	if (!bind)
 		tmate_fatal("Cannot initialize ssh");
 
+#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0,9,0)
+	/* Explicitly parse configuration to avoid automatic configuration file
+	 * loading which could override options */
+	ssh_bind_options_parse_config(bind, NULL);
+#endif
+
 	if (bind_addr)
 		ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, bind_addr);
 	ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDPORT, &port);


### PR DESCRIPTION
Since libssh 0.9.0 the global server configuration file is automatically
parsed when new connections are accepted, unless
ssh_bind_options_parse_config() is explicitly called or the automatic
parsing is disabled by setting the SSH_BIND_OPTIONS_PROCESS_CONFIG
option with false.

This adds an explicit call to ssh_bind_options_parse_config() before
setting the options to avoid them to be overridden.

Fixes #72