### PR TITLE
upgrading to alpine 3.12 and remove the libssh build stage; provides …

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,20 +1,12 @@
-FROM alpine:3.9
+FROM alpine:3.12
 
 RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib
 
 RUN set -ex; \
 	apk add --no-cache --virtual .build-deps \
+		libssh-dev \
 		git wget cmake make gcc g++ linux-headers zlib-dev openssl-dev \
 		automake autoconf libevent-dev ncurses-dev msgpack-c-dev libexecinfo-dev; \
-	\
-	mkdir -p /src/libssh/build; \
-	cd /src; \
-	wget -O libssh.tar.xz https://www.libssh.org/files/0.9/libssh-0.9.0.tar.xz; \
-	tar -xf libssh.tar.xz -C /src/libssh --strip-components=1; \
-	cd /src/libssh/build; \
-	cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DWITH_SFTP=OFF ..; \
-	make -j "$(nproc)"; \
-	make install
 
 WORKDIR /src/tmate-ssh-server
 

--- a/Dockerfile.v2.3.0
+++ b/Dockerfile.v2.3.0
@@ -1,18 +1,16 @@
 FROM alpine:3.12 AS build
 
-RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib
-
-RUN apk add --no-cache git wget cmake make gcc g++ linux-headers zlib-dev openssl-dev \
-		automake autoconf libevent-dev ncurses-dev msgpack-c-dev libexecinfo-dev
+RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib \
+		git wget cmake make gcc g++ linux-headers zlib-dev openssl-dev \
+		automake autoconf libevent-dev ncurses-dev msgpack-c-dev libexecinfo-dev \
+		libssh-dev
 
 # alpine 3.12 provides libssh-0.9.4-r0 and libssh-dev-0.9.4-r0, no need to rebuild
-RUN apk add --no-cache libssh-dev
 
-RUN mkdir -p /src/tmate-ssh-server
-COPY . /src/tmate-ssh-server
+RUN mkdir -p /src/ && wget -q https://github.com/tmate-io/tmate-ssh-server/archive/2.3.0.tar.gz -O - | ( cd /src && tar -xzf -)
 
 RUN set -ex; \
-	cd /src/tmate-ssh-server; \
+	cd /src/tmate-ssh-server-2.3.0/; \
 	./autogen.sh; \
 	./configure --prefix=/usr CFLAGS="-D_GNU_SOURCE"; \
 	make -j "$(nproc)"; \
@@ -21,7 +19,6 @@ RUN set -ex; \
 ### Minimal run-time image
 FROM alpine:3.12
 
-# alpine 3.12 provides libssh-0.9.4-r0 no need to copy from "build"
 RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib gdb bash libssh
 
 COPY --from=build /usr/bin/tmate-ssh-server /usr/bin/


### PR DESCRIPTION
Dockerfile and Dockerfile.dev : upgrade to current alpine 3.12 which provides a recent enough libssh version.
Extras: Dockerfile.v2.3.0 to build the latest 2.3.0 released version