### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-if [ "${USE_PROXY_PROTOCOL}" == "1" ]; then
+if [ "${USE_PROXY_PROTOCOL}" -eq "1" ]; then
   set -- -x "$@"
 fi
 
-if [ "${HAS_WEBSOCKET}" == "1" ]; then
+if [ "${HAS_WEBSOCKET}" -eq "1" ]; then
   set -- -w localhost "$@"
 fi
 


### PR DESCRIPTION
fix sh operator error
```
./start-tmate-ssh-server: 10: [: 1: unexpected operator
./start-tmate-ssh-server: 14: [: 1: unexpected operator
```