### PR TITLE
create_keys.sh: use #/usr/bin/env bash

### DIFF
--- a/create_keys.sh
+++ b/create_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 gen_key() {


### PR DESCRIPTION
That way, this can run when `bash` is in $PATH, which works for
distributions where it's not in /bin, like on NixOS.