### PR TITLE
Docker: add variable WEBSOCKET_HOSTNAME

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,10 @@ if [ "${HAS_WEBSOCKET}" -eq "1" ]; then
   set -- -w localhost "$@"
 fi
 
+if [ -n "${WEBSOCKET_HOSTNAME}" ]; then
+  set -- -w "${WEBSOCKET_HOSTNAME}" "$@"
+fi
+
 if [ ! -z "${SSH_HOSTNAME}" ]; then
   set -- -h "${SSH_HOSTNAME}" "$@"
 fi


### PR DESCRIPTION
To use when the websocket isn't on the same host.

This is needed for docker-compose settings where the ssh server and the
websocket are on two separate services.

Mutualy exclusive with `HAS_WEBSOCKET=1` which is the same as
`WEBSOCKET_HOSTNAME=localhost`.