### PR TITLE
 fix 'sh: out of range' warning messages 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-if [ "${USE_PROXY_PROTOCOL}" -eq "1" ]; then
+if [ "${USE_PROXY_PROTOCOL:-0}" -eq "1" ]; then
   set -- -x "$@"
 fi
 
-if [ "${HAS_WEBSOCKET}" -eq "1" ]; then
+if [ "${HAS_WEBSOCKET:-0}" -eq "1" ]; then
   set -- -w localhost "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,7 @@ if [ -n "${WEBSOCKET_HOSTNAME}" ]; then
   set -- -w "${WEBSOCKET_HOSTNAME}" "$@"
 fi
 
-if [ ! -z "${SSH_HOSTNAME}" ]; then
+if [ -n "${SSH_HOSTNAME}" ]; then
   set -- -h "${SSH_HOSTNAME}" "$@"
 fi
 
@@ -21,4 +21,4 @@ SSH_PORT_LISTEN=${SSH_PORT_LISTEN:-2200}
 SSH_PORT_ADVERTIZE=${SSH_PORT_ADVERTIZE:-${SSH_PORT_LISTEN}}
 SSH_PORT_ADVERTISE=${SSH_PORT_ADVERTISE:-${SSH_PORT_ADVERTIZE}}
 
-exec tmate-ssh-server -p ${SSH_PORT_LISTEN} -q ${SSH_PORT_ADVERTISE} -k ${SSH_KEYS_PATH} "$@"
+exec tmate-ssh-server -p "${SSH_PORT_LISTEN}" -q "${SSH_PORT_ADVERTISE}" -k "${SSH_KEYS_PATH}" "$@"


### PR DESCRIPTION
currently running tmate-ssh-server via docker prints:

```
sh: out of range
sh: out of range
Loading key /app//ssh_host_rsa_key
Loading key /app//ssh_host_ed25519_key
Accepting connections on :2200
```

this PR fixes those `sh: out of range` messages